### PR TITLE
Boilerplate for deregistration events & report service

### DIFF
--- a/account-management/src/main/java/micro/adapters/RabbitMqFacade.java
+++ b/account-management/src/main/java/micro/adapters/RabbitMqFacade.java
@@ -20,7 +20,10 @@ public class RabbitMqFacade {
     System.out.println("Starting facade");
     queue.addHandler("CustomerRegistrationRequested", this::handleCustomerRegistration);
     queue.addHandler("CustomerRetrievalRequested", this::handleGetCustomer);
+    queue.addHandler("CustomerDeregistrationRequested", this::handleCustomerDeregistration);
     queue.addHandler("MerchantRegistrationRequested", this::handleMerchantRegistration);
+    queue.addHandler("MerchantDeregistrationRequested", this::handleMerchantDeregistration);
+
     queue.addHandler("CustomerTokensRequested", this::handleCustomerTokensRequested);
     queue.addHandler("CustomerHasTokenCheckRequested", this::handleCustomerHasTokenCheckRequested);
     queue.addHandler("PaymentInformationResolutionRequested", this::handlePaymentInformationResolutionRequested);
@@ -43,11 +46,25 @@ public class RabbitMqFacade {
     service.handleGetAccount(QueryFactory.createAccountGetCommand(e, true), correlationId);
   }
 
+  public void handleCustomerDeregistration(Event e) {
+    var customerId = e.getArgument(0, String.class);
+    var correlationId = e.getArgument(1, CorrelationId.class);
+    AccountCreationCommand command = new AccountDeletionCommand(customerId, true);
+    service.handleDeleteAccount(command, correlationId);
+  }
+
   public void handleMerchantRegistration(Event e) {
     var eventPayload = e.getArgument(0, RegistrationDto.class);
     var correlationId = e.getArgument(1, CorrelationId.class);
     AccountCreationCommand command = new AccountCreationCommand(eventPayload, false);
     service.handleCreateAccount(command, correlationId);
+  }
+
+  public void handleMerchantDeregistration(Event e) {
+    var merchantId = e.getArgument(0, String.class);
+    var correlationId = e.getArgument(1, CorrelationId.class);
+    AccountCreationCommand command = new AccountDeletionCommand(merchantId, false);
+    service.handleDeleteAccount(command, correlationId);
   }
 
   public void handleCustomerTokensRequested(Event e) {

--- a/customer-facade/src/main/java/adapters/CustomerResource.java
+++ b/customer-facade/src/main/java/adapters/CustomerResource.java
@@ -33,7 +33,6 @@ public class CustomerResource {
         //queue.publish(new Event("CustomerRegistrationRequested"))
         return Response.ok(service.get(id)).build();
     }
-
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)

--- a/customer-facade/src/main/java/adapters/EventPublisher.java
+++ b/customer-facade/src/main/java/adapters/EventPublisher.java
@@ -6,6 +6,7 @@ import service.CorrelationId;
 public interface EventPublisher {
     public void emitRetrieveUserEvent(String id, CorrelationId correlationId);
     public void emitCreateUserEvent(RegistrationDto payload, CorrelationId correlationId);
-    public void emitUnregisterUserEvent();
+    public void emitReportRequestEvent(String customerId, CorrelationId correlationId);
+    public void emitUnregisterUserEvent(String customerId, CorrelationId correlationId);
     public void emitCreateTokensEvent(String customerId, String tokenNumber, CorrelationId correlationId);
 }

--- a/customer-facade/src/main/java/adapters/RabbitMqEventPublisher.java
+++ b/customer-facade/src/main/java/adapters/RabbitMqEventPublisher.java
@@ -27,7 +27,12 @@ public class RabbitMqEventPublisher implements EventPublisher {
         queue.publish(event);
     }
 
-    public void emitUnregisterUserEvent() {
-
+    public void emitUnregisterUserEvent(String customerId, CorrelationId correlationId) {
+        Event event = new Event("CustomerDeregistrationRequested", new Object[] { customerId, correlationId });
+        queue.publish(event);
+    }
+    public void emitReportRequestEvent(String customerId, CorrelationId correlationId) {
+        Event event = new Event("CustomerReportRequested", new Object[] { customerId, correlationId });
+        queue.publish(event);
     }
 }

--- a/customer-facade/src/main/java/adapters/RabbitMqFacade.java
+++ b/customer-facade/src/main/java/adapters/RabbitMqFacade.java
@@ -12,9 +12,12 @@ public class RabbitMqFacade {
     public RabbitMqFacade(MessageQueue queue, CustomerFacadeService service) {
         queue.addHandler("AccountRegistered", this::handleAccountRegistred);
         queue.addHandler("AccountRegistrationFailed", this::handleAccountRegistrationFailed);
+        queue.addHandler("AccountDeregistered", this::handleAccountDeregistred);
         queue.addHandler("CustomerRetrieved", this::handleCustomerRetrieved);
         queue.addHandler("TokensCreated", this::handleTokensCreated);
         queue.addHandler("TokensCreateFailed", this::handleTokensCreated);
+        queue.addHandler("CustomerReportCreated", this::handleReportCreated);
+
 
         this.service = service;
     }
@@ -31,6 +34,9 @@ public class RabbitMqFacade {
         service.completeRegistration(eventPayload, correlationid, false);
     }
 
+    public void handleAccountDeregistred(Event e) {
+
+    }
     public void handleCustomerRetrieved(Event e) { 
         var eventPayload = e.getArgument(0, AccountTokensDto.class);
         var correlationid = e.getArgument(1, CorrelationId.class);
@@ -41,5 +47,9 @@ public class RabbitMqFacade {
         var successful = e.getType().equals("TokensCreated");
         var correlationid = e.getArgument(0, CorrelationId.class);
         service.completeTokenCreationRequest(successful, correlationid);
+    }
+
+    public void handleReportCreated(Event e) { 
+
     }
 }

--- a/merchant-facade/src/main/java/adapters/EventPublisher.java
+++ b/merchant-facade/src/main/java/adapters/EventPublisher.java
@@ -7,5 +7,7 @@ import service.CorrelationId;
 public interface EventPublisher {
     public void emitCreateUserEvent(RegistrationDto payload, CorrelationId correlationId);
     public void emitInitialisePayment(PaymentDto payload, CorrelationId correlationId);
-    public void emitUnregisterUserEvent();
+    public void emitUnregisterUserEvent(String merchantId, CorrelationId correlationId);
+    public void emitReportRequestEvent(String merchantId, CorrelationId correlationId);
+
 }

--- a/merchant-facade/src/main/java/adapters/RabbitMqEventPublisher.java
+++ b/merchant-facade/src/main/java/adapters/RabbitMqEventPublisher.java
@@ -18,12 +18,18 @@ public class RabbitMqEventPublisher implements EventPublisher {
         queue.publish(event);
     }
 
+    public void emitUnregisterUserEvent(String merchantId, CorrelationId correlationId) {
+        Event event = new Event("MerchantDeregistrationRequested", new Object[] { merchantId, correlationId });
+        queue.publish(event);
+    }
+
     public void emitInitialisePayment(PaymentDto payload, CorrelationId correlationId) {
         Event event = new Event("PaymentRequested", new Object[] { payload, correlationId });
         queue.publish(event);
     }
 
-    public void emitUnregisterUserEvent() {
-
+    public void emitReportRequestEvent(String merchantId, CorrelationId correlationId) {
+        Event event = new Event("MerchantReportRequested", new Object[] { merchantId, correlationId });
+        queue.publish(event);
     }
 }

--- a/merchant-facade/src/main/java/adapters/RabbitMqFacade.java
+++ b/merchant-facade/src/main/java/adapters/RabbitMqFacade.java
@@ -10,10 +10,11 @@ public class RabbitMqFacade {
 
     public RabbitMqFacade(MessageQueue queue, MerchantFacadeService service) {
         queue.addHandler("AccountRegistered", this::handleMerchantRegistration);
+        queue.addHandler("AccountDeregistered", this::handleAccountDeregistred);
         queue.addHandler("PaymentSucceeded", this::handlePaymentSucceeded);
         queue.addHandler("PaymentFailed", this::handlePaymentFailed);
-        
-        
+        queue.addHandler("MerchantReportCreated", this::handleReportCreated);
+
         this.service = service;
     }
 
@@ -21,6 +22,10 @@ public class RabbitMqFacade {
         var eventPayload = e.getArgument(0, String.class);
         var correlationid = e.getArgument(1, CorrelationId.class);
         service.completeRegistration(eventPayload, correlationid);
+    }
+    
+    public void handleAccountDeregistred(Event e) {
+
     }
 
     private void handlePaymentSucceeded(Event e) {
@@ -31,5 +36,9 @@ public class RabbitMqFacade {
     private void handlePaymentFailed(Event e) {
         var correlationid = e.getArgument(0, CorrelationId.class);
         service.completePaymentTransaction(false, correlationid);
+    }
+
+    public void handleReportCreated(Event e) { 
+
     }
 }


### PR DESCRIPTION
## Missing:

**Customer/Merchant-facade :**

- handleReportCreated  plus service, api endpoint (ig print the report?)
- handleAccountDeregistered plus service,api endpoint

**Account management service:** 

- AccountDeletionCommand(accountId, isCustomer)
- service.handleDeleteAccount(command, correlationId);

## Question:
Also for report service, what is the event that will trigger the service to store the payment? Because on payment service the "PaymentResolved" event only has a transactionId field. I get that it is useful for the external communication with the bank but maybe we should include the payment object instead of the transactionId in the payload of this event.